### PR TITLE
fix: 멘토링 취소 2일 전 -> 24시간 전으로 수정

### DIFF
--- a/src/main/java/pheonix/classconnect/backend/mentoring/service/MentoringService.java
+++ b/src/main/java/pheonix/classconnect/backend/mentoring/service/MentoringService.java
@@ -30,6 +30,7 @@ import pheonix.classconnect.backend.mentoring.repository.MentoringResultReposito
 import pheonix.classconnect.backend.mentoring.repository.ScheduleRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -229,8 +230,9 @@ public class MentoringService {
             throw new MainApplicationException(ErrorCode.MENTORING_INVALID_STATUS_CHANGE, "승인 대기 또는 승인 상태인 요청만 거절할 수 있습니다.");
         }
         // 4. 멘토링 요청 거절 가능 기간인지 조회
-        if (Objects.equals(request.getStatus(), MentoringStatus.승인) && LocalDate.now().isAfter(request.getDate().minusDays(2))) {
-            throw new MainApplicationException(ErrorCode.MENTORING_INVALID_STATUS_CHANGE, "승인된 멘토링은 최소 2일 전까지 취소 가능합니다.");
+        if (Objects.equals(request.getStatus(), MentoringStatus.승인) &&
+                LocalDateTime.now().isAfter(LocalDateTime.of(request.getDate(), request.getStartTime()).minusHours(24))) {
+            throw new MainApplicationException(ErrorCode.MENTORING_INVALID_STATUS_CHANGE, "승인된 멘토링은 멘토링 시작 24시간 전까지 취소 가능합니다.");
         }
 
         request.cancel(comment);


### PR DESCRIPTION
## 변경 사항 요약

- 멘토링 취소 검증 로직 개선

## 상세 변경 사항

- `MentoringService.cancelRequest()` 검증 로직 개선
- AS-IS : 멘토링 시작일 2일 전까지 취소 가능
- TO-BE : 멘토링 시작일 24시간 전까지 취소 가능

```java
// 4. 멘토링 요청 거절 가능 기간인지 조회
        // AS-IS
        if (Objects.equals(request.getStatus(), MentoringStatus.승인) && LocalDate.now().isAfter(request.getDate().minusDays(2))) {
            throw new MainApplicationException(ErrorCode.MENTORING_INVALID_STATUS_CHANGE, "승인된 멘토링은 최소 2일 전까지 취소 가능합니다.");
        // TO-BE
        if (Objects.equals(request.getStatus(), MentoringStatus.승인) &&
                LocalDateTime.now().isAfter(LocalDateTime.of(request.getDate(), request.getStartTime()).minusHours(24))) {
            throw new MainApplicationException(ErrorCode.MENTORING_INVALID_STATUS_CHANGE, "승인된 멘토링은 멘토링 시작 24시간 전까지 취소 가능합니다.");
        }
```

## 관련 이슈

없음

## 추가 정보

없음

## 체크리스트

- [ ] 필요한 테스트를 모두 완료했나요?
- [ ] 코드 스타일 가이드를 따랐나요?
- [ ] 변경사항을 문서화했나요?
- [ ] 모든 변경사항이 잘 동작하는지 확인했나요?
- [ ] 관련된 모든 이슈에 대해 적절하게 링크를 걸었나요?

