### PR TITLE
FIX: 멘토링 리마인더 알림 문구 수정

### DIFF
--- a/src/main/java/pheonix/classconnect/backend/mentoring/contants/MentoringStatus.java
+++ b/src/main/java/pheonix/classconnect/backend/mentoring/contants/MentoringStatus.java
@@ -4,7 +4,7 @@ public class MentoringStatus {
     public static final Short 승인대기 = 1;
     public static final Short 승인 = 2;
     public static final Short 반려 = 3;
-    public static final Short 멘토취소 = 4;
-    public static final Short 멘티취소 = 5;
+    public static final Short 멘티취소 = 4;
+    public static final Short 멘토취소 = 5;
     public static final Short 삭제 = 9;
 }

--- a/src/main/java/pheonix/classconnect/backend/notification/service/NotificationService.java
+++ b/src/main/java/pheonix/classconnect/backend/notification/service/NotificationService.java
@@ -159,8 +159,10 @@ public class NotificationService {
         List<NotificationEntity> notifications = new ArrayList<>();
 
         for (MentoringRequestEntity request : requests) {
-            String content = "멘토링이 예정되어 있습니다. 시간: "
-                    + request.getStartTime() + " - " + request.getEndTime();
+            String content = "멘토링이 예정되어 있습니다. ["
+                    + request.getDate() + " "
+                    + request.getStartTime() + " - " + request.getEndTime()
+                    + "]";
 
 
             if (request.getMentor() != null && request.getRequester() != null) {


### PR DESCRIPTION
## 변경 사항 요약

멘토링 리마인더 알림 문구 수정

## 상세 변경 사항

문구 수정
- OOO님과 멘토링이 예정되어 있습니다. 시간: hh:mm - hh:mm
- => OOO님과 멘토링이 예정되어 있습니다. [yyyy-mm-dd hh:mm - hh:mm]

```java
// /backend/notification/service/NotificationService.java:161

/*AS-IS*/
        for (MentoringRequestEntity request : requests) {
            String content = "멘토링이 예정되어 있습니다. 시간: "
                    + request.getStartTime() + " - " + request.getEndTime();

/*TO-BE*/
        for (MentoringRequestEntity request : requests) {
            String content = "멘토링이 예정되어 있습니다. ["
                    + request.getDate() + " "
                    + request.getStartTime() + " - " + request.getEndTime()
                    + "]";
```

## 관련 이슈

이 PR이 해결하거나 관련된 GitHub 이슈가 있다면 여기에 링크합니다. 예: `#123`

## 추가 정보

이 변경사항을 이해하는데 도움이 될 수 있는 추가 정보나 문맥, 테스트 방법 등을 제공합니다.

## 체크리스트

- [ ] 필요한 테스트를 모두 완료했나요?
- [ ] 코드 스타일 가이드를 따랐나요?
- [ ] 변경사항을 문서화했나요?
- [ ] 모든 변경사항이 잘 동작하는지 확인했나요?
- [ ] 관련된 모든 이슈에 대해 적절하게 링크를 걸었나요?

